### PR TITLE
Fix for Linux build.

### DIFF
--- a/libSpace/Makefile
+++ b/libSpace/Makefile
@@ -19,7 +19,7 @@ CXX      = g++
 CXXFLAGS = -g -W -Wall -fPIC -I.
 
 LINK     = g++
-LFLAGS   = -headerpad_max_install_names -single_module -dynamiclib -compatibility_version 1.0 -current_version 1.0.0 -install_name libSpace.1.dylib
+LFLAGS  = -headerpad_max_install_names -single_module -dynamiclib -compatibility_version 1.0 -current_version 1.0.0 -install_name libSpace.1.dylib
 
 RM       = rm -f
 LN       = ln -s
@@ -38,6 +38,17 @@ TARGET0 = libSpace.dylib
 TARGET1 = libSpace.1.dylib
 TARGET2 = libSpace.1.0.dylib
 
+# Detect operating system flavor.
+UNAME   := $(shell uname)
+
+# .dylib is only for Darwin, so remove the target.
+ifneq ($(UNAME), Darwin)
+TARGET = 
+TARGET0 = 
+TARGET1 = 
+TARGET2 = 
+endif
+
 # builds
 
 $(TARGET): $(OBJECTS) $(INCLUDES)
@@ -54,7 +65,7 @@ $(TARGETA): $(OBJECTS) $(INCLUDES)
 	$(AR) $(TARGETA) $(OBJECTS)
 	$(RANLIB) $(TARGETA)
 
-all: main
+all: staticlib main
 
 main: main.o $(TARGET)
 	g++ main.o -o main -L. -lSpace

--- a/libSpace/space.cpp
+++ b/libSpace/space.cpp
@@ -23,6 +23,7 @@
 // ==================================================================
 
 
+#include <stdlib.h>  /* strtod */
 #include <space.h>
 
 // stand-ins until c++ 11
@@ -183,7 +184,7 @@ Cartesian::rotator::rotator(const Cartesian::rotator& rhs) :
 
 // TODO use swap http://en.wikipedia.org/wiki/Assignment_operator_(C%2B%2B)
 Cartesian::rotator&
-Cartesian::rotator::operator=(const Cartesian::rotator::rotator& rhs) {
+Cartesian::rotator::operator=(const Cartesian::rotator& rhs) {
   if (this == &rhs) return *this;
   axis(rhs.axis());
   m_rotation_matrix = rhs.m_rotation_matrix;

--- a/libSpace/space.h
+++ b/libSpace/space.h
@@ -148,7 +148,7 @@ namespace Cartesian {
   // ---------------------------------------------------
 
   // copy constructor
-  inline space::space(const space::space& a) {
+  inline space::space(const space& a) {
     m_x = a.x();
     m_y = a.y();
     m_z = a.z();
@@ -156,7 +156,7 @@ namespace Cartesian {
 
   // copy assignment
   // TODO use swap http://en.wikipedia.org/wiki/Assignment_operator_(C%2B%2B)
-  inline space& space::operator=(const space::space& rhs) {
+  inline space& space::operator=(const space& rhs) {
     if (this == &rhs) return *this;
     m_x = rhs.x();
     m_y = rhs.y();
@@ -166,11 +166,11 @@ namespace Cartesian {
 
   // ----- bool operators -----
 
-  inline bool space::operator== (const space::space& rhs) const {
+  inline bool space::operator== (const space& rhs) const {
     return x() == rhs.x() && y() == rhs.y() && z() == rhs.z();
   }
 
-  inline bool space::operator!= (const space::space& rhs) const {
+  inline bool space::operator!= (const space& rhs) const {
     return !operator==(rhs);
   }
 


### PR DESCRIPTION
1) Excluded .dylib builds for non-Darwin systems. 
2) Add missing "staticlib" dependency to "all" target.
3) Add missing <stdlib.h> include (probably Linux-specific.)
4) Fixed "... names the constructor, not the type" errors.
